### PR TITLE
fixed typo on base.html footer

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -83,7 +83,7 @@
 			<a class="cc-license-link" rel="license" href="http://creativecommons.org/licenses/by/4.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a>
 			<br>
 			<br>
-			<span>We will never enforce this license in any way;<br>This just means it would be kind to follow <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a> when using these infographics. :)</span>
+			<span>We will never enforce this license in any way.<br>This just means it would be kind to follow <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a> when using these infographics. :)</span>
 		</div>
 	</div>
 


### PR DESCRIPTION
Fixed and replaced a ';' with a '.' in the footer of base.html. Initially opened the PR to fix a typo on the index page 'Wha does it really mean to have bitcoins?' but then realize that it was a DB entry.